### PR TITLE
Support displaying json in transactions note field.

### DIFF
--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -1518,6 +1518,15 @@ class OrdersController extends Controller
                     $transactionResponse = Json::htmlEncode($transactionResponse);
                 }
 
+                $transactionNoteType = 'text';
+                $transactionNote = Json::decodeIfJson($transaction->note);
+                if (is_array($transactionNote)) {
+                    $transactionNoteType = 'response';
+                    $transactionNote = Json::htmlEncode($transactionNote);
+                } else {
+                    $transactionNote = Html::encode($transaction->note);
+                }
+
                 $transactionMessage = Json::decodeIfJson($transaction->message);
                 $transactionMessage = Json::htmlEncode($transactionMessage);
 
@@ -1541,7 +1550,7 @@ class OrdersController extends Controller
                         ['label' => Html::encode(Craft::t('commerce', 'Transaction Hash')), 'type' => 'code', 'value' => $transaction->hash],
                         ['label' => Html::encode(Craft::t('commerce', 'Gateway Reference')), 'type' => 'code', 'value' => $transaction->reference],
                         ['label' => Html::encode(Craft::t('commerce', 'Gateway Message')), 'type' => 'text', 'value' => $transactionMessage],
-                        ['label' => Html::encode(Craft::t('commerce', 'Note')), 'type' => 'text', 'value' => Html::encode($transaction->note)],
+                        ['label' => Html::encode(Craft::t('commerce', 'Note')), 'type' => $transactionNoteType, 'value' => $transactionNote],
                         ['label' => Html::encode(Craft::t('commerce', 'Gateway Code')), 'type' => 'code', 'value' => $transaction->code],
                         ['label' => Html::encode(Craft::t('commerce', 'Converted Price')), 'type' => 'text', 'value' => Plugin::getInstance()->getPaymentCurrencies()->convert($transaction->paymentAmount, $transaction->paymentCurrency) . ' <small class="light">(' . $transaction->currency . ')</small>' . ' <small class="light">(1 ' . $transaction->currency . ' = ' . number_format($transaction->paymentRate) . ' ' . $transaction->paymentCurrency . ')</small>'],
                         ['label' => Html::encode(Craft::t('commerce', 'Gateway Response')), 'type' => 'response', 'value' => $transactionResponse],


### PR DESCRIPTION
We use the transactions model note property to store a json string, been super helpful providing extra detail to our app where we need to extend the refund logic.

Issue is the cp tooltip can't parse that json note, this pr adds a little tweak to handle this and means our cp users can see the info they need:

<img width="48%" alt="Screenshot 2024-03-26 at 10 38 20" src="https://github.com/findarace/commerce/assets/1846063/c1c242af-4e93-4eb4-b911-89833c9929b3"> <img width="48%" alt="Screenshot 2024-03-26 at 09 28 13" src="https://github.com/findarace/commerce/assets/1846063/4a104b94-5a9c-4265-b603-694083fcc90e">
